### PR TITLE
accept color strings as palettes

### DIFF
--- a/iqplot/cat.py
+++ b/iqplot/cat.py
@@ -673,8 +673,10 @@ def stripbox(
         box_kwargs = dict(line_color="gray", fill_alpha=0)
     if "color" not in box_kwargs and "line_color" not in box_kwargs:
         box_kwargs["line_color"] = "gray"
-    if "fill_alpha" not in box_kwargs:
+    if ("fill_alpha" not in box_kwargs) and ("fill_color" not in box_kwargs):
         box_kwargs["fill_alpha"] = 0
+    elif ("fill_color" in box_kwargs) and ("fill_alpha" not in box_kwargs):
+        box_kwargs["fill_alpha"] = 0.5
 
     if median_kwargs is None:
         median_kwargs = dict(line_color="gray")

--- a/iqplot/dist.py
+++ b/iqplot/dist.py
@@ -60,9 +60,9 @@ def ecdf(
         Name of column(s) to use as categorical variable(s).
     q_axis : str, either 'x' or 'y', default 'x'
         Axis along which the quantitative value varies.
-    palette : list of strings of hex colors, or single hex string
+    palette : list colors, or single color string 
         If a list, color palette to use. If a single string representing
-        a hex color, all glyphs are colored with that color. Default is
+        a color, all glyphs are colored with that color. Default is
         colorcet.b_glasbey_category10 from the colorcet package.
     order : list or None
         If not None, must be a list of unique group names when the input
@@ -157,6 +157,8 @@ def ecdf(
 
     if palette is None:
         palette = colorcet.b_glasbey_category10
+    elif type(palette) == str:
+        palette = [palette]
 
     data, q, cats, show_legend = utils._data_cats(
         data, q, cats, show_legend, legend_label
@@ -397,9 +399,9 @@ def histogram(
         Name of column(s) to use as categorical variable(s).
     q_axis : str, either 'x' or 'y', default 'x'
         Axis along which the quantitative value varies.
-    palette : list of strings of hex colors, or single hex string
+    palette : list colors, or single color string 
         If a list, color palette to use. If a single string representing
-        a hex color, all glyphs are colored with that color. Default is
+        a color, all glyphs are colored with that color. Default is
         colorcet.b_glasbey_category10 from the colorcet package.
     order : list or None
         If not None, must be a list of unique group names when the input
@@ -483,6 +485,8 @@ def histogram(
 
     if palette is None:
         palette = colorcet.b_glasbey_category10
+    elif type(palette) == str:
+        palette = [palette]
 
     df, q, cats, show_legend = utils._data_cats(
         data, q, cats, show_legend, legend_label

--- a/iqplot/utils.py
+++ b/iqplot/utils.py
@@ -206,8 +206,8 @@ def _check_cat_input(
     if q is None:
         raise RuntimeError("`q` argument must be provided.")
 
-    if type(palette) not in [list, tuple]:
-        raise RuntimeError("`palette` must be a list or tuple.")
+    if type(palette) not in [list, tuple, str]:
+        raise RuntimeError("`palette` must be a list, tuple or string.")
 
     if q not in df.columns:
         raise RuntimeError(f"{q} is not a column in the inputted data frame")


### PR DESCRIPTION
`palette` argument accepts single strings as input for both `iqplot.ecdf()` and `iqplot.histrogram`.